### PR TITLE
Use path.join for file resolution and log unfindable source file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var through = require( 'through2' );
 var gutil = require( 'gulp-util' );
 var fs = require( 'fs' );
+var path = require('path');
 
 module.exports = function ( option ) {
     'use strict';
@@ -89,7 +90,7 @@ module.exports = function ( option ) {
 
             contents = contents.replace( new RegExp( option.match_pattern, 'gi' ), function ( match, parameters ) {
                 var attrs = getAttributes( parameters );
-                return getStyleFile( option.path + attrs.src );
+                return getStyleFile( path.join(option.path , attrs.src) );
             } );
 
             file.contents = new Buffer( contents );

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function ( option ) {
         if ( source && fs.existsSync( source ) ) {
             return transformResponse( fs.readFileSync( source ) );
         } else {
-            throwError( 'ERROR: Source file cannot be found.' );
+            throwError( 'ERROR: Source file (' + source + ') cannot be found.' );
         }
     }
 


### PR DESCRIPTION
1. Instead of a simple string concatenation of the path defined in the options with the path defined in the html, use node's built-in path package to join these. This allows for better file resolution when using relative ('./') or parent ('../') prefixes inside the 'inline-style' directive. In the old case I personally came across the issue where adding ./ in front of my files killed all file resolution.
2. Log the file source that can not be found with the error. It took some manual logging for me to find the problem in 1. Logging the file generally helps seeing where things go wrong anyways.