### PR TITLE
replaced deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through = require( 'through2' );
-var gutil = require( 'gulp-util' );
+var PluginError = require('plugin-error');
 var fs = require( 'fs' );
 var path = require('path');
 
@@ -19,7 +19,7 @@ module.exports = function ( option ) {
             new RegExp( option.match_pattern );
         } catch ( e ) {
             this.emit( 'error',
-                new gutil.PluginError( 'gulp-style-inject', ' Invalid `match_pattern` parameter. Regular expression string required.' ) );
+                new PluginError( 'gulp-style-inject', ' Invalid `match_pattern` parameter. Regular expression string required.' ) );
         }
     } else {
         option.match_pattern = CONST_PATTERN;
@@ -37,7 +37,7 @@ module.exports = function ( option ) {
 
     function throwError( msg ) {
         self.emit( 'error',
-            new gutil.PluginError( 'gulp-style-inject', msg ) );
+            new PluginError( 'gulp-style-inject', msg ) );
     }
 
     function transformResponse( contents ) {
@@ -80,7 +80,7 @@ module.exports = function ( option ) {
         if ( file.isStream() ) {
             // accepting streams is optional
             this.emit( 'error',
-                new gutil.PluginError( 'gulp-style-inject', 'Stream content is not supported' ) );
+                new PluginError( 'gulp-style-inject', 'Stream content is not supported' ) );
             return callback();
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gulp-style-inject",
-    "version": "0.1.0",
+    "version": "0.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -17,15 +17,18 @@
             "dev": true,
             "optional": true
         },
-        "ansi-regex": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-            "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        },
-        "ansi-styles": {
+        "ansi-colors": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-            "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "requires": {
+                "ansi-wrap": "^0.1.0"
+            }
+        },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "argparse": {
             "version": "0.1.16",
@@ -33,24 +36,19 @@
             "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
             "dev": true,
             "requires": {
-                "underscore": "1.7.0",
-                "underscore.string": "2.4.0"
+                "underscore": "~1.7.0",
+                "underscore.string": "~2.4.0"
             }
         },
-        "array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-        },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "asn1": {
             "version": "0.1.11",
@@ -66,6 +64,11 @@
             "dev": true,
             "optional": true
         },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
         "async": {
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -79,60 +82,39 @@
             "dev": true,
             "optional": true
         },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-        },
         "boom": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
             "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
             "dev": true,
             "requires": {
-                "hoek": "0.9.1"
-            }
-        },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-        },
-        "camelcase": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
-            }
-        },
-        "chalk": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-            "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-            "requires": {
-                "ansi-styles": "1.1.0",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "0.1.0",
-                "strip-ansi": "0.3.0",
-                "supports-color": "0.2.0"
+                "hoek": "0.9.x"
             }
         },
         "clone": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
         },
         "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+        },
+        "cloneable-readable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+            "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            }
         },
         "combined-stream": {
             "version": "0.0.7",
@@ -174,7 +156,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "boom": "0.4.2"
+                "boom": "0.4.x"
             }
         },
         "ctype": {
@@ -184,23 +166,6 @@
             "dev": true,
             "optional": true
         },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "requires": {
-                "array-find-index": "1.0.2"
-            }
-        },
-        "dateformat": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-            "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-            "requires": {
-                "get-stdin": "4.0.1",
-                "meow": "3.7.0"
-            }
-        },
         "debug": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
@@ -209,11 +174,6 @@
             "requires": {
                 "ms": "0.6.2"
             }
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "delayed-stream": {
             "version": "0.0.5",
@@ -234,37 +194,16 @@
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "requires": {
-                "readable-stream": "1.1.14"
-            }
-        },
-        "error-ex": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-            "requires": {
-                "is-arrayish": "0.2.1"
-            }
-        },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
         "escodegen": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
             "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
             "dev": true,
             "requires": {
-                "esprima": "1.1.1",
-                "estraverse": "1.5.1",
-                "esutils": "1.0.0",
-                "source-map": "0.1.43"
+                "esprima": "~1.1.1",
+                "estraverse": "~1.5.0",
+                "esutils": "~1.0.0",
+                "source-map": "~0.1.33"
             },
             "dependencies": {
                 "esprima": {
@@ -299,13 +238,22 @@
             "integrity": "sha1-95+ZhMB+4/2bRP+zzQQisT4kCE0=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
+            }
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             }
         },
         "fileset": {
@@ -314,17 +262,8 @@
             "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
             "dev": true,
             "requires": {
-                "glob": "3.2.11",
-                "minimatch": "0.4.0"
-            }
-        },
-        "find-up": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "glob": "3.x",
+                "minimatch": "0.x"
             }
         },
         "forever-agent": {
@@ -340,9 +279,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "async": "0.9.2",
-                "combined-stream": "0.0.7",
-                "mime": "1.2.11"
+                "async": "~0.9.0",
+                "combined-stream": "~0.0.4",
+                "mime": "~1.2.11"
             }
         },
         "from": {
@@ -351,19 +290,14 @@
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
         },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-        },
         "glob": {
             "version": "3.2.11",
             "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
             "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimatch": "0.3.0"
+                "inherits": "2",
+                "minimatch": "0.3"
             },
             "dependencies": {
                 "minimatch": {
@@ -372,16 +306,11 @@
                     "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
-        },
-        "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "growl": {
             "version": "1.8.1",
@@ -389,44 +318,14 @@
             "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
             "dev": true
         },
-        "gulp-util": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.3.tgz",
-            "integrity": "sha1-OweNCQAae193u+LnQC4F2X14s+Q=",
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "0.5.1",
-                "dateformat": "1.0.12",
-                "lodash.reescape": "3.0.1",
-                "lodash.reevaluate": "3.0.1",
-                "lodash.reinterpolate": "3.0.1",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "2.1.1",
-                "replace-ext": "0.0.1",
-                "through2": "0.6.3",
-                "vinyl": "0.4.6"
-            }
-        },
         "handlebars": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
             "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
             "dev": true,
             "requires": {
-                "optimist": "0.3.7",
-                "uglify-js": "2.3.6"
-            }
-        },
-        "has-ansi": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-            "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-            "requires": {
-                "ansi-regex": "0.2.1"
+                "optimist": "~0.3",
+                "uglify-js": "~2.3"
             }
         },
         "hawk": {
@@ -436,10 +335,10 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "boom": "0.4.2",
-                "cryptiles": "0.2.2",
-                "hoek": "0.9.1",
-                "sntp": "0.2.4"
+                "boom": "0.4.x",
+                "cryptiles": "0.2.x",
+                "hoek": "0.9.x",
+                "sntp": "0.2.x"
             }
         },
         "hoek": {
@@ -447,11 +346,6 @@
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
             "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
             "dev": true
-        },
-        "hosted-git-info": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-            "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
         },
         "http-signature": {
             "version": "0.10.1",
@@ -461,16 +355,8 @@
             "optional": true,
             "requires": {
                 "asn1": "0.1.11",
-                "assert-plus": "0.1.5",
+                "assert-plus": "^0.1.5",
                 "ctype": "0.5.3"
-            }
-        },
-        "indent-string": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-            "requires": {
-                "repeating": "2.0.1"
             }
         },
         "inherits": {
@@ -478,36 +364,31 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+        "is-extendable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
             "requires": {
-                "builtin-modules": "1.1.1"
+                "is-plain-object": "^2.0.4"
             }
         },
-        "is-finite": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
-                "number-is-nan": "1.0.1"
+                "isobject": "^3.0.1"
             }
-        },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
         },
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "istanbul": {
             "version": "0.3.5",
@@ -515,19 +396,19 @@
             "integrity": "sha1-75ykwdXmpd6sIkWEIFG1l2Oi3jc=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.9",
-                "async": "0.9.2",
-                "escodegen": "1.3.3",
-                "esprima": "1.2.5",
-                "fileset": "0.1.8",
-                "handlebars": "1.3.0",
-                "js-yaml": "3.0.1",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "once": "1.4.0",
-                "resolve": "0.7.4",
-                "which": "1.0.9",
-                "wordwrap": "0.0.3"
+                "abbrev": "1.0.x",
+                "async": "0.9.x",
+                "escodegen": "1.3.x",
+                "esprima": "1.2.x",
+                "fileset": "0.1.x",
+                "handlebars": "1.3.x",
+                "js-yaml": "3.x",
+                "mkdirp": "0.5.x",
+                "nopt": "3.x",
+                "once": "1.x",
+                "resolve": "0.7.x",
+                "which": "1.0.x",
+                "wordwrap": "0.0.x"
             },
             "dependencies": {
                 "esprima": {
@@ -568,8 +449,8 @@
             "integrity": "sha1-dkBf6lvOMPyPQF1Ixtyn8KMsav4=",
             "dev": true,
             "requires": {
-                "argparse": "0.1.16",
-                "esprima": "1.0.4"
+                "argparse": "~ 0.1.11",
+                "esprima": "~ 1.0.2"
             }
         },
         "json-stringify-safe": {
@@ -584,159 +465,11 @@
             "integrity": "sha1-gZ5dqL8HkfnT857qXtGGgYfxEXU=",
             "dev": true
         },
-        "load-json-file": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
-            }
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "requires": {
-                "lodash._root": "3.0.1"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
-        },
-        "lodash.reescape": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.reescape/-/lodash.reescape-3.0.1.tgz",
-            "integrity": "sha1-FtJ9RZGoOaELE83/YdyWJO0jeiM=",
-            "requires": {
-                "lodash._reescape": "3.0.0"
-            }
-        },
-        "lodash.reevaluate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.reevaluate/-/lodash.reevaluate-3.0.1.tgz",
-            "integrity": "sha1-b2fKyoXJW/1I8d8lniU9QJiMp2Q=",
-            "requires": {
-                "lodash._reevaluate": "3.0.0"
-            }
-        },
-        "lodash.reinterpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.reinterpolate/-/lodash.reinterpolate-3.0.1.tgz",
-            "integrity": "sha1-YaqgZn8KXFIan4wxoGxyuLaE1rA=",
-            "requires": {
-                "lodash._reinterpolate": "3.0.0"
-            }
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
-            }
-        },
         "log-driver": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz",
             "integrity": "sha1-LWLX+u9F2KcTQZYaBLB2HsqZz6M=",
             "dev": true
-        },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
-            }
         },
         "lru-cache": {
             "version": "2.7.3",
@@ -744,40 +477,11 @@
             "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
             "dev": true
         },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-        },
         "map-stream": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
-        },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                }
-            }
         },
         "mime": {
             "version": "1.2.11",
@@ -798,14 +502,9 @@
             "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
             "dev": true,
             "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
             }
-        },
-        "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mkdirp": {
             "version": "0.5.1",
@@ -852,9 +551,9 @@
                     "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "2.0.3",
-                        "inherits": "2.0.3",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~2.0.0",
+                        "inherits": "2",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -869,8 +568,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 },
                 "minimist": {
@@ -902,14 +601,6 @@
             "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
             "dev": true
         },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "requires": {
-                "duplexer2": "0.0.2"
-            }
-        },
         "node-uuid": {
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
@@ -922,24 +613,8 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.9"
+                "abbrev": "1"
             }
-        },
-        "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-            "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
             "version": "0.3.0",
@@ -948,18 +623,13 @@
             "dev": true,
             "optional": true
         },
-        "object-assign": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-            "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "optimist": {
@@ -968,33 +638,7 @@
             "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
             "dev": true,
             "requires": {
-                "wordwrap": "0.0.3"
-            }
-        },
-        "parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "requires": {
-                "error-ex": "1.3.1"
-            }
-        },
-        "path-exists": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "requires": {
-                "pinkie-promise": "2.0.1"
-            }
-        },
-        "path-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "wordwrap": "~0.0.2"
             }
         },
         "pause-stream": {
@@ -1003,26 +647,24 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "plugin-error": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+            "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
             "requires": {
-                "pinkie": "2.0.4"
+                "ansi-colors": "^1.0.1",
+                "arr-diff": "^4.0.0",
+                "arr-union": "^3.1.0",
+                "extend-shallow": "^3.0.2"
             }
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "punycode": {
             "version": "1.4.1",
@@ -1037,57 +679,44 @@
             "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g=",
             "dev": true
         },
-        "read-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
-            }
-        },
-        "read-pkg-up": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-            }
-        },
         "readable-stream": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
-            }
-        },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "requires": {
-                "is-finite": "1.0.2"
-            }
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "replace-ext": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+            "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
         },
         "request": {
             "version": "2.40.0",
@@ -1095,19 +724,19 @@
             "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.5.0",
-                "forever-agent": "0.5.2",
-                "form-data": "0.1.4",
+                "aws-sign2": "~0.5.0",
+                "forever-agent": "~0.5.0",
+                "form-data": "~0.1.0",
                 "hawk": "1.1.1",
-                "http-signature": "0.10.1",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "1.0.2",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.3.0",
-                "qs": "1.0.2",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.4.3"
+                "http-signature": "~0.10.0",
+                "json-stringify-safe": "~5.0.0",
+                "mime-types": "~1.0.1",
+                "node-uuid": "~1.4.0",
+                "oauth-sign": "~0.3.0",
+                "qs": "~1.0.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": ">=0.12.0",
+                "tunnel-agent": "~0.4.0"
             }
         },
         "resolve": {
@@ -1116,10 +745,10 @@
             "integrity": "sha1-OVqe+ehz+/4SvRRAi9kbuTYAPWk=",
             "dev": true
         },
-        "semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "should": {
             "version": "5.0.0",
@@ -1162,11 +791,6 @@
             "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
         },
-        "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
         "sntp": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
@@ -1174,7 +798,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "hoek": "0.9.1"
+                "hoek": "0.9.x"
             }
         },
         "source-map": {
@@ -1184,36 +808,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
-        },
-        "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-            "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "split": {
             "version": "0.3.3",
@@ -1221,7 +817,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "stream-combiner": {
@@ -1230,7 +826,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "string_decoder": {
@@ -1245,35 +841,6 @@
             "dev": true,
             "optional": true
         },
-        "strip-ansi": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-            "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-            "requires": {
-                "ansi-regex": "0.2.1"
-            }
-        },
-        "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "requires": {
-                "is-utf8": "0.2.1"
-            }
-        },
-        "strip-indent": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-            "requires": {
-                "get-stdin": "4.0.1"
-            }
-        },
-        "supports-color": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-            "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-        },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1285,8 +852,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
             "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
             "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
             },
             "dependencies": {
                 "readable-stream": {
@@ -1294,10 +861,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 }
             }
@@ -1309,13 +876,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
-        },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
         },
         "tunnel-agent": {
             "version": "0.4.3",
@@ -1331,9 +893,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "async": "0.2.10",
-                "optimist": "0.3.7",
-                "source-map": "0.1.43"
+                "async": "~0.2.6",
+                "optimist": "~0.3.5",
+                "source-map": "~0.1.7"
             },
             "dependencies": {
                 "async": {
@@ -1357,22 +919,22 @@
             "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
             "dev": true
         },
-        "validate-npm-package-license": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-            "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
-            }
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vinyl": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gulp-style-inject",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A plugin for Gulp. Inject css file into html style tags.",
     "keywords": [
         "gulpplugin"
@@ -16,8 +16,9 @@
         "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
     },
     "dependencies": {
+        "plugin-error": "^1.0.1",
         "through2": "0.6.3",
-        "gulp-util": "3.0.3"
+        "vinyl": "^2.2.0"
     },
     "devDependencies": {
         "mocha": "2.1.0",

--- a/test/main.js
+++ b/test/main.js
@@ -9,21 +9,21 @@ require( 'mocha' );
 
 delete require.cache[ require.resolve( '../' ) ];
 
-var gutil = require( 'gulp-util' ),
+var Vinyl = require('vinyl'),
     styleInject = require( '../' );
 
 describe( 'gulp-style-inject', function () {
 
     it( 'should produce expected file via buffer', function ( done ) {
 
-        var srcFile = new gutil.File( {
+        var srcFile = new Vinyl( {
             path: 'test/fixtures/index.html',
             cwd: 'test/',
             base: 'test/fixtures',
             contents: fs.readFileSync( 'test/fixtures/index.html' )
         } );
 
-        var expectedFile = new gutil.File( {
+        var expectedFile = new Vinyl( {
             path: 'test/expected/index.html',
             cwd: 'test/',
             base: 'test/expected',
@@ -53,7 +53,7 @@ describe( 'gulp-style-inject', function () {
 
     it( 'should error on stream', function ( done ) {
 
-        var srcFile = new gutil.File( {
+        var srcFile = new Vinyl( {
             path: 'test/fixtures/index.html',
             cwd: 'test/',
             base: 'test/fixtures',


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been recently deprecated. Continuing to use this dependency may prevent the use of your library with the latest release of Gulp 4 so **it is important to replace `gulp-util`**.
 
The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

Closes #8 

See:

* https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
* [gulpjs/gulp-util#143](https://github.com/gulpjs/gulp-util/issues/143)

